### PR TITLE
Added client secret support that is missing since original JS SDK

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -14,10 +14,11 @@ class Client {
     String region,
     String service = 'AWSCognitoIdentityProviderService',
     http.Client client,
+    String userAgent = 'aws-amplify/0.0.x dart',
   }) {
     this._region = region;
     this._service = service;
-    this._userAgent = 'aws-amplify/0.0.x dart';
+    this._userAgent = userAgent;
     this.endpoint = endpoint ?? 'https://cognito-idp.$_region.amazonaws.com/';
     this._client = client;
     if (this._client == null) {

--- a/lib/src/cognito_user.dart
+++ b/lib/src/cognito_user.dart
@@ -37,6 +37,7 @@ class CognitoUser {
   String _session;
   CognitoUserSession _signInUserSession;
   String username;
+  String _clientSecretHash;
   CognitoUserPool pool;
   Client client;
   String authenticationFlowType;
@@ -47,9 +48,13 @@ class CognitoUser {
   CognitoUser(
     this.username,
     this.pool, {
+    clientSecret,
     this.storage,
     this.deviceName = 'Dart-device',
   }) {
+    if (clientSecret != null) {
+      _clientSecretHash = calculateClientSecretHash(username, pool.getClientId(), clientSecret);
+    }
     client = pool.client;
     authenticationFlowType = 'USER_SRP_AUTH';
 
@@ -244,6 +249,9 @@ class CognitoUser {
       final deviceKeyKey = '$keyPrefix.${this.username}.deviceKey';
       _deviceKey = await this.storage.getItem(deviceKeyKey);
       authParameters['DEVICE_KEY'] = _deviceKey;
+      if (_clientSecretHash != null) {
+        authParameters['SECRET_HASH'] = _clientSecretHash;
+      }
     }
 
     final Map<String, dynamic> paramsReq = {
@@ -335,6 +343,9 @@ class CognitoUser {
     };
     final aValue = authenticationHelper.getLargeAValue();
     authParameters['SRP_A'] = aValue.toRadixString(16);
+    if (_clientSecretHash != null) {
+      authParameters['SECRET_HASH'] = _clientSecretHash;
+    }
 
     Map<String, dynamic> params = {
       'ChallengeName': 'DEVICE_SRP_AUTH',
@@ -373,6 +384,10 @@ class CognitoUser {
       'PASSWORD_CLAIM_SIGNATURE': signatureString,
       'DEVICE_KEY': _deviceKey,
     };
+
+    if (_clientSecretHash != null) {
+      challengeResponses['SECRET_HASH'] = _clientSecretHash;
+    }
 
     Map<String, dynamic> paramsResp = {
       'ChallengeName': 'DEVICE_PASSWORD_VERIFIER',
@@ -473,7 +488,7 @@ class CognitoUser {
       pool.getUserPoolId().split('_')[1],
     );
 
-    getCachedDeviceKeyAndPassword();
+    await getCachedDeviceKeyAndPassword();
     if (_deviceKey != null) {
       authParameters['DEVICE_KEY'] = _deviceKey;
     }
@@ -504,6 +519,7 @@ class CognitoUser {
     BigInt salt;
 
     Map<String, String> authParameters = {};
+    await getCachedDeviceKeyAndPassword();
     if (_deviceKey != null) {
       authParameters['DEVICE_KEY'] = _deviceKey;
     }
@@ -514,6 +530,10 @@ class CognitoUser {
 
     if (authenticationFlowType == 'CUSTOM_AUTH') {
       authParameters['CHALLENGE_NAME'] = 'SRP_A';
+    }
+
+    if (_clientSecretHash != null) {
+      authParameters['SECRET_HASH'] = _clientSecretHash;
     }
 
     Map<String, dynamic> params = {
@@ -533,7 +553,6 @@ class CognitoUser {
     this.username = challengeParameters['USER_ID_FOR_SRP'];
     serverBValue = BigInt.parse(challengeParameters['SRP_B'], radix: 16);
     salt = BigInt.parse(challengeParameters['SALT'], radix: 16);
-    getCachedDeviceKeyAndPassword();
 
     var hkdf = authenticationHelper.getPasswordAuthenticationKey(
       this.username,
@@ -563,6 +582,10 @@ class CognitoUser {
 
     if (_deviceKey != null) {
       challengeResponses['DEVICE_KEY'] = _deviceKey;
+    }
+
+    if (_clientSecretHash != null) {
+      challengeResponses['SECRET_HASH'] = _clientSecretHash;
     }
 
     Future<dynamic> respondToAuthChallenge(challenge) async {
@@ -630,6 +653,16 @@ class CognitoUser {
     return _authenticateUserInternal(dataAuthenticate, authenticationHelper);
   }
 
+  ///
+  /// Translated from library `aws-android-sdk-cognitoprovider@2.6.30` file `CognitoSecretHash.java::getSecretHash()`
+  ///
+  static String calculateClientSecretHash(String userName, String clientId, String clientSecret) {
+    Hmac hmac = new Hmac(sha256, utf8.encode(clientSecret));
+    Digest digest = hmac.convert(utf8.encode(userName + clientId));
+    hmac.convert(digest.bytes);
+    return base64.encode(digest.bytes);
+  }
+
   /// This is used for a certain user to confirm the registration by using a confirmation code
   Future<bool> confirmRegistration(String confirmationCode,
       [bool forceAliasCreation = false]) async {
@@ -670,7 +703,7 @@ class CognitoUser {
     final authenticationHelper =
         new AuthenticationHelper(pool.getUserPoolId().split('_')[1]);
 
-    getCachedDeviceKeyAndPassword();
+    await getCachedDeviceKeyAndPassword();
     if (_deviceKey != null) {
       challengeResponses['DEVICE_KEY'] = _deviceKey;
     }
@@ -744,6 +777,7 @@ class CognitoUser {
       challengeResponses['SOFTWARE_TOKEN_MFA_CODE'] = confirmationCode;
     }
 
+    await getCachedDeviceKeyAndPassword();
     if (_deviceKey != null) {
       challengeResponses['DEVICE_KEY'] = _deviceKey;
     }
@@ -826,6 +860,9 @@ class CognitoUser {
       'ProposedPassword': newUserPassword,
       'AccessToken': _signInUserSession.getAccessToken().getJwtToken(),
     };
+    if (_clientSecretHash != null) {
+      paramsReq['SecretHash'] = _clientSecretHash;
+    }
     await client.request('ChangePassword', paramsReq);
 
     return true;
@@ -876,6 +913,9 @@ class CognitoUser {
       'ClientId': pool.getClientId(),
       'Username': username,
     };
+    if (_clientSecretHash != null) {
+      paramsReq['SecretHash'] = _clientSecretHash;
+    }
     if (getUserContextData() != null) {
       paramsReq['UserContextData'] = getUserContextData();
     }
@@ -892,6 +932,9 @@ class CognitoUser {
       'ConfirmationCode': confirmationCode,
       'Password': newPassword,
     };
+    if (_clientSecretHash != null) {
+      paramsReq['SecretHash'] = _clientSecretHash;
+    }
     if (getUserContextData() != null) {
       paramsReq['UserContextData'] = getUserContextData();
     }


### PR DESCRIPTION
Same as: https://github.com/jonsaw/amazon-cognito-identity-dart/pull/63

What are in this PR:

1. Client secret support, see [my blog](http://tsuinte.ru/2019/flutter_log_2_cognito/#1-Client-secret-support) for more details. Maybe there are other requests that need this `SECRET_HASH` parameters, I just tested a few flows like sign up/login/password reset
2. Allow setting a custom user agent in the request