### PR TITLE
Guest auth support

### DIFF
--- a/lib/src/cognito_credentials.dart
+++ b/lib/src/cognito_credentials.dart
@@ -6,11 +6,11 @@ import 'cognito_identity_id.dart';
 import 'cognito_user_pool.dart';
 
 class CognitoCredentials {
-  String _region;
-  String _userPoolId;
-  String _identityPoolId;
-  CognitoUserPool _pool;
-  Client _client;
+  final String _region;
+  final String _identityPoolId;
+  final CognitoUserPool _pool;
+  final Client _client;
+
   int _retryCount = 0;
   String accessKeyId;
   String secretAccessKey;
@@ -18,55 +18,67 @@ class CognitoCredentials {
   int expireTime;
   String userIdentityId;
 
-  CognitoCredentials(String identityPoolId, CognitoUserPool pool,
-      {String region, String userPoolId}) {
-    _pool = pool;
-    _region = region ?? pool.getRegion();
-    _userPoolId = userPoolId ?? pool.getUserPoolId();
-    _identityPoolId = identityPoolId;
-    _client = pool.client;
-  }
+  CognitoCredentials(
+    this._identityPoolId,
+    this._pool, {
+    String region,
+    String userPoolId,
+  })  : _region = region ?? _pool.getRegion(),
+        _client = _pool.client;
 
   /// Get AWS Credentials for authenticated user
   Future<void> getAwsCredentials(token, [String authenticator]) async {
-    if (expireTime == null ||
-        DateTime.now().millisecondsSinceEpoch > expireTime - 60000) {
-      final identityId = CognitoIdentityId(_identityPoolId, _pool);
-      userIdentityId = await identityId.getIdentityId(token, authenticator);
+    if (!(expireTime == null ||
+        DateTime.now().millisecondsSinceEpoch > expireTime - 60000)) {
+      return;
+    }
 
-      authenticator ??= 'cognito-idp.$_region.amazonaws.com/$_userPoolId';
-      final Map<String, String> loginParam = {
-        authenticator: token,
-      };
-      final Map<String, dynamic> paramsReq = {
-        'IdentityId': userIdentityId,
-        'Logins': loginParam,
-      };
+    final identityId = CognitoIdentityId(_identityPoolId, _pool,
+        token: token, authenticator: authenticator);
+    _getAwsCredentials(identityId);
+  }
 
-      var data;
-      try {
-        data = await _client.request('GetCredentialsForIdentity', paramsReq,
-            service: 'AWSCognitoIdentityService',
-            endpoint: 'https://cognito-identity.$_region.amazonaws.com/');
-      } on CognitoClientException catch (e) {
-        // remove cached Identity Id and try again
-        await identityId.removeIdentityId();
-        if (e.code == 'NotAuthorizedException' && _retryCount < 1) {
-          _retryCount++;
-          return await getAwsCredentials(token);
-        }
+  Future<void> getGuestAwsCredentialsId() async {
+    if (!(expireTime == null ||
+        DateTime.now().millisecondsSinceEpoch > expireTime - 60000)) {
+      return;
+    }
 
-        _retryCount = 0;
-        throw e;
+    final identityId = CognitoIdentityId(_identityPoolId, _pool);
+    return _getAwsCredentials(identityId);
+  }
+
+  Future<void> _getAwsCredentials(CognitoIdentityId identityId) async {
+    userIdentityId = await identityId.getIdentityId();
+
+    final Map<String, dynamic> paramsReq = {'IdentityId': userIdentityId};
+    if (identityId.loginParam != null) {
+      paramsReq['Logins'] = identityId.loginParam;
+    }
+
+    var data;
+    try {
+      data = await _client.request('GetCredentialsForIdentity', paramsReq,
+          service: 'AWSCognitoIdentityService',
+          endpoint: 'https://cognito-identity.$_region.amazonaws.com/');
+    } on CognitoClientException catch (e) {
+      // remove cached Identity Id and try again
+      await identityId.removeIdentityId();
+      if (e.code == 'NotAuthorizedException' && _retryCount < 1) {
+        _retryCount++;
+        return await _getAwsCredentials(identityId);
       }
 
       _retryCount = 0;
-
-      accessKeyId = data['Credentials']['AccessKeyId'];
-      secretAccessKey = data['Credentials']['SecretKey'];
-      sessionToken = data['Credentials']['SessionToken'];
-      expireTime = (data['Credentials']['Expiration']).toInt() * 1000;
+      throw e;
     }
+
+    _retryCount = 0;
+
+    accessKeyId = data['Credentials']['AccessKeyId'];
+    secretAccessKey = data['Credentials']['SecretKey'];
+    sessionToken = data['Credentials']['SessionToken'];
+    expireTime = (data['Credentials']['Expiration']).toInt() * 1000;
   }
 
   /// Reset AWS Credentials; removes Identity Id from local storage

--- a/lib/src/cognito_identity_id.dart
+++ b/lib/src/cognito_identity_id.dart
@@ -5,41 +5,52 @@ import 'cognito_user_pool.dart';
 
 class CognitoIdentityId {
   String identityId;
-  String _identityPoolId;
-  String _userPoolId;
-  CognitoUserPool _pool;
-  Client _client;
-  String _region;
-  CognitoIdentityId(String identityPoolId, CognitoUserPool pool) {
-    _identityPoolId = identityPoolId;
-    _pool = pool;
-    _userPoolId = pool.getUserPoolId();
-    _region = pool.getRegion();
-    _client = pool.client;
-  }
+  final String _identityPoolId;
+  final String _userPoolId;
+  final CognitoUserPool _pool;
+  final Client _client;
+  final String _region;
+  final String _identityIdKey;
+
+  CognitoIdentityId(this._identityPoolId, this._pool)
+      : _userPoolId = _pool.getUserPoolId(),
+        _region = _pool.getRegion(),
+        _client = _pool.client,
+        _identityIdKey = 'aws.cognito.identity-id.$_identityPoolId';
 
   /// Get AWS Identity Id for authenticated user
   Future<String> getIdentityId(token, [String authenticator]) async {
-    final identityIdKey = 'aws.cognito.identity-id.$_identityPoolId';
-    String identityId = await _pool.storage.getItem(identityIdKey);
-    if (identityId != null) {
-      this.identityId = identityId;
-      return identityId;
-    }
     authenticator ??= 'cognito-idp.$_region.amazonaws.com/$_userPoolId';
     final Map<String, String> loginParam = {
       authenticator: token,
     };
-    final Map<String, dynamic> paramsReq = {
-      'IdentityPoolId': _identityPoolId,
-      'Logins': loginParam,
-    };
+
+    return _getCognitoIdentityId(loginParam);
+  }
+
+  Future<String> getGuestIdentityId() async {
+    return _getCognitoIdentityId();
+  }
+
+  Future<String> _getCognitoIdentityId([Map<String, String> loginParam]) async {
+    String identityId = await _pool.storage.getItem(_identityIdKey);
+    if (identityId != null) {
+      this.identityId = identityId;
+      return identityId;
+    }
+
+    final Map<String, dynamic> paramsReq = {'IdentityPoolId': _identityPoolId};
+
+    if (loginParam != null) {
+      paramsReq['Logins'] = loginParam;
+    }
+
     final data = await _client.request('GetId', paramsReq,
         service: 'AWSCognitoIdentityService',
         endpoint: 'https://cognito-identity.$_region.amazonaws.com/');
 
     this.identityId = data['IdentityId'];
-    await _pool.storage.setItem(identityIdKey, this.identityId);
+    await _pool.storage.setItem(_identityIdKey, this.identityId);
 
     return this.identityId;
   }

--- a/lib/src/cognito_identity_id.dart
+++ b/lib/src/cognito_identity_id.dart
@@ -29,6 +29,8 @@ class CognitoIdentityId {
     }
   }
 
+  Map<String, String> get loginParam => _loginParam;
+
   Future<String> getIdentityId() async {
     String identityId = await _pool.storage.getItem(_identityIdKey);
     if (identityId != null) {


### PR DESCRIPTION
This pull allows unauthenticated access to identity pools identities and AWS credentials. I changed the constructor for `CognitoIdentityId` since it wasn't in the docs.

I would like to change `CognitoCredentials` constructor in a similar way, passing in `token` and `authenticator`, so that the `CognitoIdentityId` could be cached, but it would require changing the public API and docs, so I left it for now. 

Alternatively, the change could mirror amplify-cognito-identity-js even more, passing in `Logins` like
```javascript
new AWS.CognitoIdentityCredentials({
  IdentityPoolId: '...', // your identity pool id here
  Logins: {
    // Change the key below according to the specific region your user pool is in.
    'cognito-idp.<region>.amazonaws.com/<YOUR_USER_POOL_ID>': result
      .getIdToken()
      .getJwtToken(),
  },
});
```