### PR TITLE
fix - type 'List<dynamic>' is not a subtype of type 'List<int>'

### DIFF
--- a/lib/src/cognito_user.dart
+++ b/lib/src/cognito_user.dart
@@ -586,7 +586,7 @@ class CognitoUser {
     final dateNow = dateHelper.getNowString();
 
     final signature = Hmac(sha256, hkdf);
-    final signatureData = [];
+    final List<int> signatureData = [];
     signatureData
       ..addAll(utf8.encode(pool.getUserPoolId().split('_')[1]))
       ..addAll(utf8.encode(username))


### PR DESCRIPTION
error during login process caused by dart auto typing system, that assign signatureData variable as List<dynamic> instead of List<int> this was causing this exception: type 'List<dynamic>' is not a subtype of type 'List<int>'