### PR TITLE
Fix getUserAttributes strict casting issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.12+2
+- fix: getUserAttributes strict casting issue
+
 ## 0.1.12+1
 - fix: type 'List<dynamic>' is not a subtype of type 'List<int>'
 

--- a/lib/src/cognito_user.dart
+++ b/lib/src/cognito_user.dart
@@ -1052,7 +1052,7 @@ class CognitoUser {
       return null;
     }
 
-    final attributeList = [];
+    final attributeList = <CognitoUserAttribute>[];
     userData['UserAttributes'].forEach((attr) {
       attributeList
           .add(CognitoUserAttribute(name: attr['Name'], value: attr['Value']));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: amazon_cognito_identity_dart_2
-version: 0.1.12+1
+version: 0.1.12+2
 homepage: https://github.com/furaiev/amazon-cognito-identity-dart-2
 description: Unofficial Amazon Cognito Identity Provider Dart SDK,
   to add user sign-up / sign-in to your mobile and web apps


### PR DESCRIPTION
As reported by #39, calling getUserAttributes throws the exception:
type 'List<dynamic>' is not a subtype of type 'FutureOr<List<CognitoUserAttribute>>'


