### PR TITLE
update default content type for hash.

### DIFF
--- a/lib/sig_v4.dart
+++ b/lib/sig_v4.dart
@@ -10,7 +10,7 @@ const _x_amz_date = 'x-amz-date';
 const _x_amz_security_token = 'x-amz-security-token';
 const _host = 'host';
 const _authorization = 'Authorization';
-const _default_content_type = 'application/json';
+const _default_content_type = 'application/json; charset=utf-8';
 const _default_accept_type = 'application/json';
 
 class AwsSigV4Client {


### PR DESCRIPTION
The default content type is affecting Carnonical hash for post request.
Unless user manually set headers['Content-Type']="application/json; charset=utf-8";
If not needed can just reject this.