### PR TITLE
Exposes cognigo device key, which is available in AWS Android/iOS SDK.

### DIFF
--- a/lib/src/cognito_user.dart
+++ b/lib/src/cognito_user.dart
@@ -294,6 +294,18 @@ class CognitoUser {
     return username;
   }
 
+  /// Returns the cached key for this device. Device keys are stored in local storage and are used to track devices.
+  /// Returns `null` if no device key was cached.
+  Future<String> getDeviceKey() async {
+    // Return device key if it has been loaded or updated
+    if (_deviceKey != null) {
+      return _deviceKey;
+    }
+    // Otherwise, load from local storage
+    await getCachedDeviceKeyAndPassword();
+    return _deviceKey;
+  }
+
   String getAuthenticationFlowType() {
     return authenticationFlowType;
   }


### PR DESCRIPTION
Added a new method to expose the cognito device key, which can be used to track devices or other things with your own customized APIs. 

It's already available in the AWS official Android/iOS SDK as well, so would be good to have it