### PR TITLE
remove unused flutter_test dev dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,8 +11,6 @@ dependencies:
   convert: ^2.1.1
 
 dev_dependencies:
-  flutter_test:
-    sdk: flutter
   pedantic: 1.9.0
   test: ^1.4.0
 


### PR DESCRIPTION
This package has an unused dev_dependency for flutter_test. 
This causes this package and all dependents to be flagged as incompatible with vanilla (flutter-less) Dart.

This PR removes this dependency (note: this does not affect the example, which still can use flutteR) 