### PR TITLE
Using an app client secret with '_authenticateUserPlainUsernamePassword' was not working

### DIFF
--- a/lib/src/cognito_user.dart
+++ b/lib/src/cognito_user.dart
@@ -499,6 +499,9 @@ class CognitoUser {
       'USERNAME': username,
       'PASSWORD': authDetails.getPassword(),
     };
+    if (_clientSecretHash != "") {
+      authParameters['SECRET_HASH'] = _clientSecretHash;
+    }
     if (authParameters['PASSWORD'] == null) {
       throw ArgumentError('PASSWORD parameter is required');
     }


### PR DESCRIPTION
I added code with wich you can use an app client secret (if the app client was configured within Cognito like that) with `USER_PASSWORD_AUTH` auth flow.

If this change is needed for other login flows too, I don't know right now.

With these changes I was able to get the tokens from login flow `USER_PASSWORD_AUTH`.