### PR TITLE
Added SecretHash to ConfirmSignUp/ResendConfirmationCode request parameters

### DIFF
--- a/lib/src/cognito_user.dart
+++ b/lib/src/cognito_user.dart
@@ -729,6 +729,11 @@ class CognitoUser {
       'ClientId': pool.getClientId(),
       'Username': username,
     };
+
+    if (_clientSecretHash != null) {
+      params['SecretHash'] = _clientSecretHash;
+    }
+
     var data = await client.request('ResendConfirmationCode', params);
 
     return data;

--- a/lib/src/cognito_user.dart
+++ b/lib/src/cognito_user.dart
@@ -715,6 +715,10 @@ class CognitoUser {
       params['UserContextData'] = getUserContextData();
     }
 
+    if (_clientSecretHash != null) {
+      params['SecretHash'] = _clientSecretHash;
+    }
+
     await client.request('ConfirmSignUp', params);
     return true;
   }


### PR DESCRIPTION
SecretHash is required to prevent 'Unable to verify secret hash for client' error on ConfirmSignUp and ResendConfirmationCode