### PR TITLE
Removed `getLargeAValue` call on `AuthenticationHelper` initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+- removed: `getLargeAValue` call on `AuthenticationHelper` initialization
+
 ## 0.1.19
 - added: additional getters for CognitoJwtToken
 

--- a/lib/src/authentication_helper.dart
+++ b/lib/src/authentication_helper.dart
@@ -46,7 +46,6 @@ class AuthenticationHelper {
       radix: 16,
     );
     _smallAValue = generateRandomSmallA();
-    getLargeAValue();
     _infoBits = utf8.encode('Caldera Derived Key');
   }
 
@@ -85,7 +84,7 @@ class AuthenticationHelper {
     if (serverBValue % N == BigInt.zero) {
       throw ArgumentError('B cannot be zero.');
     }
-    _uValue = calculateU(_largeAValue, serverBValue);
+    _uValue = calculateU(getLargeAValue(), serverBValue);
     if (_uValue == BigInt.zero) {
       throw ArgumentError('U cannot be zero.');
     }


### PR DESCRIPTION
Calculated value is not used in every authentication flow, hence there is no need to calculate it for every flow that wants to use `AuthenticationHelper`

Calculation was causing a significant lag in the UI, blocking the main thread for about 3 seconds. Probably, there's an issue in DDC compiler that causes it. When compiled using `dart2js` lag was about 700ms.

DDC:
![image](https://user-images.githubusercontent.com/5956619/100766220-72c81f80-3409-11eb-9225-e8c368e90b37.png)

dart2js:
![image](https://user-images.githubusercontent.com/5956619/100768214-a99f3500-340b-11eb-88b9-4a91d26d40a9.png)

