### PR TITLE
[Issue #69] Adding support for AnalyticsMetadata request parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.22
+- [Issue #69] Adding support for AnalyticsMetadata request parameter
+
 ## 0.1.21
 - failed AWS request with specific character
 

--- a/lib/src/cognito_user.dart
+++ b/lib/src/cognito_user.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:amazon_cognito_identity_dart_2/src/params_decorators.dart';
 import 'package:convert/convert.dart';
 import 'package:crypto/crypto.dart';
 
@@ -43,6 +44,7 @@ class CognitoUser {
   String deviceName;
   String verifierDevices;
   CognitoStorage storage;
+  final ParamsDecorator analyticsMetadataParamsDecorator;
 
   CognitoUser(
     this.username,
@@ -51,7 +53,9 @@ class CognitoUser {
     this.storage,
     this.deviceName = 'Dart-device',
     signInUserSession,
-  }) {
+    ParamsDecorator analyticsMetadataParamsDecorator,
+  }) : analyticsMetadataParamsDecorator = analyticsMetadataParamsDecorator ??
+            AnalyticsMetadataParamsDecorator(null) {
     if (clientSecret != null) {
       _clientSecretHash =
           calculateClientSecretHash(username, pool.getClientId(), clientSecret);
@@ -263,6 +267,7 @@ class CognitoUser {
     if (getUserContextData() != null) {
       paramsReq['UserContextData'] = getUserContextData();
     }
+    analyticsMetadataParamsDecorator.call(paramsReq);
 
     var authResult;
     try {
@@ -368,6 +373,7 @@ class CognitoUser {
     if (getUserContextData() != null) {
       params['UserContextData'] = getUserContextData();
     }
+    analyticsMetadataParamsDecorator.call(params);
 
     final data = await client.request('RespondToAuthChallenge', params);
     final challengeParameters = data['ChallengeParameters'];
@@ -413,6 +419,7 @@ class CognitoUser {
     if (getUserContextData() != null) {
       paramsResp['UserContextData'] = getUserContextData();
     }
+    analyticsMetadataParamsDecorator.call(paramsResp);
 
     final dataAuthenticate =
         await client.request('RespondToAuthChallenge', paramsResp);
@@ -447,6 +454,7 @@ class CognitoUser {
     if (getUserContextData() != null) {
       paramsReq['UserContextData'] = getUserContextData();
     }
+    analyticsMetadataParamsDecorator.call(paramsReq);
 
     final data = await client.request('InitiateAuth', paramsReq);
 
@@ -525,6 +533,7 @@ class CognitoUser {
     if (getUserContextData() != null) {
       paramsReq['UserContextData'] = getUserContextData();
     }
+    analyticsMetadataParamsDecorator.call(paramsReq);
     final authResult = await client.request('InitiateAuth', paramsReq);
 
     return _authenticateUserInternal(authResult, authenticationHelper);
@@ -569,6 +578,7 @@ class CognitoUser {
     if (getUserContextData() != null) {
       params['UserContextData'] = getUserContextData();
     }
+    analyticsMetadataParamsDecorator.call(params);
 
     var data;
     try {
@@ -657,6 +667,7 @@ class CognitoUser {
     if (getUserContextData() != null) {
       jsonReqResp['UserContextData'] = getUserContextData();
     }
+    analyticsMetadataParamsDecorator.call(jsonReqResp);
 
     final dataAuthenticate = await respondToAuthChallenge(jsonReqResp);
 
@@ -718,6 +729,7 @@ class CognitoUser {
     if (_clientSecretHash != null) {
       params['SecretHash'] = _clientSecretHash;
     }
+    analyticsMetadataParamsDecorator.call(params);
 
     await client.request('ConfirmSignUp', params);
     return true;
@@ -733,6 +745,7 @@ class CognitoUser {
     if (_clientSecretHash != null) {
       params['SecretHash'] = _clientSecretHash;
     }
+    analyticsMetadataParamsDecorator.call(params);
 
     var data = await client.request('ResendConfirmationCode', params);
 
@@ -769,6 +782,7 @@ class CognitoUser {
     if (getUserContextData() != null) {
       paramsReq['UserContextData'] = getUserContextData();
     }
+    analyticsMetadataParamsDecorator.call(paramsReq);
 
     final data = await client.request('RespondToAuthChallenge', paramsReq);
 
@@ -811,6 +825,7 @@ class CognitoUser {
     if (getUserContextData() != null) {
       paramsReq['UserContextData'] = getUserContextData();
     }
+    analyticsMetadataParamsDecorator.call(paramsReq);
 
     final data = await client.request('RespondToAuthChallenge', paramsReq);
 
@@ -842,6 +857,7 @@ class CognitoUser {
     if (getUserContextData() != null) {
       paramsReq['UserContextData'] = getUserContextData();
     }
+    analyticsMetadataParamsDecorator.call(paramsReq);
 
     final dataAuthenticate =
         await client.request('RespondToAuthChallenge', paramsReq);
@@ -984,6 +1000,7 @@ class CognitoUser {
     if (getUserContextData() != null) {
       paramsReq['UserContextData'] = getUserContextData();
     }
+    analyticsMetadataParamsDecorator.call(paramsReq);
 
     return await client.request('ForgotPassword', paramsReq);
   }
@@ -1003,6 +1020,7 @@ class CognitoUser {
     if (getUserContextData() != null) {
       paramsReq['UserContextData'] = getUserContextData();
     }
+    analyticsMetadataParamsDecorator.call(paramsReq);
 
     await client.request('ConfirmForgotPassword', paramsReq);
     return true;

--- a/lib/src/cognito_user_pool.dart
+++ b/lib/src/cognito_user_pool.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'package:amazon_cognito_identity_dart_2/src/params_decorators.dart';
+
 import 'attribute_arg.dart';
 import 'client.dart';
 import 'cognito_storage.dart';
@@ -30,6 +32,7 @@ class CognitoUserPool {
   Client client;
   CognitoStorage storage;
   String _userAgent;
+  final ParamsDecorator analyticsMetadataParamsDecorator;
 
   CognitoUserPool(
     String userPoolId,
@@ -40,7 +43,9 @@ class CognitoUserPool {
     String customUserAgent,
     this.storage,
     this.advancedSecurityDataCollectionFlag = true,
-  }) {
+    ParamsDecorator analyticsMetadataParamsDecorator,
+  }) : analyticsMetadataParamsDecorator = analyticsMetadataParamsDecorator ??
+            AnalyticsMetadataParamsDecorator(null) {
     _userPoolId = userPoolId;
     _clientId = clientId;
     _clientSecret = clientSecret;
@@ -116,6 +121,7 @@ class CognitoUserPool {
       params['SecretHash'] = CognitoUser.calculateClientSecretHash(
           username, _clientId, _clientSecret);
     }
+    analyticsMetadataParamsDecorator.call(params);
 
     final data = await client.request('SignUp', params);
     if (data == null) {

--- a/lib/src/params_decorators.dart
+++ b/lib/src/params_decorators.dart
@@ -1,0 +1,18 @@
+abstract class ParamsDecorator {
+  void call(Map<String, Object> params);
+}
+
+class AnalyticsMetadataParamsDecorator extends ParamsDecorator {
+  final String _analyticsEndpointId;
+
+  AnalyticsMetadataParamsDecorator(this._analyticsEndpointId);
+
+  @override
+  void call(Map<String, Object> params) {
+    if (_analyticsEndpointId != null) {
+      params['AnalyticsMetadata'] = {
+        'AnalyticsEndpointId': _analyticsEndpointId
+      };
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: amazon_cognito_identity_dart_2
-version: 0.1.21
+version: 0.1.22
 homepage: https://github.com/furaiev/amazon-cognito-identity-dart-2
 description: Unofficial Amazon Cognito Identity Provider Dart SDK,
   to add user sign-up / sign-in to your mobile and web apps


### PR DESCRIPTION
Several Amazon Cognito Identity Provider's actions (like [InitiateAuth](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_InitiateAuth.html#API_InitiateAuth_RequestSyntax)) accept AnalyticsMetadata as request parameter.

This [allows](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AnalyticsMetadataType.html) to send Cognito events to Amazon Pinpoint analytics.

@furaiev Could you please review this pull-request?

Thanks.