### PR TITLE
[Issue #69] Solving "type '_InternalLinkedHashMap<String, String>' is not a subtype of type 'String' of 'value'" bug when ParamsDecorator receives a Map<String, String>.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.25
+- [Issue #69] Solving "type '_InternalLinkedHashMap<String, String>' is not a subtype of type 'String' of 'value'" bug when ParamsDecorator receives a Map<String, String>.
+
 ## 0.1.24+2
 - [Issue #103] Set confirmed to true when email or phone_number is verified
 

--- a/lib/src/cognito_user.dart
+++ b/lib/src/cognito_user.dart
@@ -267,11 +267,11 @@ class CognitoUser {
     if (getUserContextData() != null) {
       paramsReq['UserContextData'] = getUserContextData();
     }
-    await _analyticsMetadataParamsDecorator.call(paramsReq);
 
     var authResult;
     try {
-      authResult = await client.request('InitiateAuth', paramsReq);
+      authResult = await client.request('InitiateAuth',
+          await _analyticsMetadataParamsDecorator.call(paramsReq));
     } on CognitoClientException catch (e) {
       if (e.code == 'NotAuthorizedException') {
         await clearCachedTokens();
@@ -373,9 +373,9 @@ class CognitoUser {
     if (getUserContextData() != null) {
       params['UserContextData'] = getUserContextData();
     }
-    await _analyticsMetadataParamsDecorator.call(params);
 
-    final data = await client.request('RespondToAuthChallenge', params);
+    final data = await client.request('RespondToAuthChallenge',
+        await _analyticsMetadataParamsDecorator.call(params));
     final challengeParameters = data['ChallengeParameters'];
     final serverBValue = BigInt.parse(challengeParameters['SRP_B'], radix: 16);
     final saltString =
@@ -419,10 +419,9 @@ class CognitoUser {
     if (getUserContextData() != null) {
       paramsResp['UserContextData'] = getUserContextData();
     }
-    await _analyticsMetadataParamsDecorator.call(paramsResp);
 
-    final dataAuthenticate =
-        await client.request('RespondToAuthChallenge', paramsResp);
+    final dataAuthenticate = await client.request('RespondToAuthChallenge',
+        await _analyticsMetadataParamsDecorator.call(paramsResp));
 
     _signInUserSession =
         getCognitoUserSession(dataAuthenticate['AuthenticationResult']);
@@ -454,9 +453,9 @@ class CognitoUser {
     if (getUserContextData() != null) {
       paramsReq['UserContextData'] = getUserContextData();
     }
-    await _analyticsMetadataParamsDecorator.call(paramsReq);
 
-    final data = await client.request('InitiateAuth', paramsReq);
+    final data = await client.request('InitiateAuth',
+        await _analyticsMetadataParamsDecorator.call(paramsReq));
 
     final String challengeName = data['ChallengeName'];
     final challengeParameters = data['ChallengeParameters'];
@@ -533,8 +532,8 @@ class CognitoUser {
     if (getUserContextData() != null) {
       paramsReq['UserContextData'] = getUserContextData();
     }
-    await _analyticsMetadataParamsDecorator.call(paramsReq);
-    final authResult = await client.request('InitiateAuth', paramsReq);
+    final authResult = await client.request('InitiateAuth',
+        await _analyticsMetadataParamsDecorator.call(paramsReq));
 
     return _authenticateUserInternal(authResult, authenticationHelper);
   }
@@ -578,11 +577,11 @@ class CognitoUser {
     if (getUserContextData() != null) {
       params['UserContextData'] = getUserContextData();
     }
-    await _analyticsMetadataParamsDecorator.call(params);
 
     var data;
     try {
-      data = await client.request('InitiateAuth', params);
+      data = await client.request(
+          'InitiateAuth', await _analyticsMetadataParamsDecorator.call(params));
     } on CognitoClientException catch (e) {
       if (e.name == 'UserNotConfirmedException') {
         throw CognitoUserConfirmationNecessaryException();
@@ -667,9 +666,9 @@ class CognitoUser {
     if (getUserContextData() != null) {
       jsonReqResp['UserContextData'] = getUserContextData();
     }
-    await _analyticsMetadataParamsDecorator.call(jsonReqResp);
 
-    final dataAuthenticate = await respondToAuthChallenge(jsonReqResp);
+    final dataAuthenticate = await respondToAuthChallenge(
+        await _analyticsMetadataParamsDecorator.call(jsonReqResp));
 
     final challengeName = dataAuthenticate['ChallengeName'];
     if (challengeName == 'NEW_PASSWORD_REQUIRED') {
@@ -729,9 +728,9 @@ class CognitoUser {
     if (_clientSecretHash != null) {
       params['SecretHash'] = _clientSecretHash;
     }
-    await _analyticsMetadataParamsDecorator.call(params);
 
-    await client.request('ConfirmSignUp', params);
+    await client.request(
+        'ConfirmSignUp', await _analyticsMetadataParamsDecorator.call(params));
     return true;
   }
 
@@ -745,9 +744,9 @@ class CognitoUser {
     if (_clientSecretHash != null) {
       params['SecretHash'] = _clientSecretHash;
     }
-    await _analyticsMetadataParamsDecorator.call(params);
 
-    var data = await client.request('ResendConfirmationCode', params);
+    var data = await client.request('ResendConfirmationCode',
+        await _analyticsMetadataParamsDecorator.call(params));
 
     return data;
   }
@@ -782,9 +781,9 @@ class CognitoUser {
     if (getUserContextData() != null) {
       paramsReq['UserContextData'] = getUserContextData();
     }
-    await _analyticsMetadataParamsDecorator.call(paramsReq);
 
-    final data = await client.request('RespondToAuthChallenge', paramsReq);
+    final data = await client.request('RespondToAuthChallenge',
+        await _analyticsMetadataParamsDecorator.call(paramsReq));
 
     return _authenticateUserInternal(data, authenticationHelper);
   }
@@ -825,9 +824,9 @@ class CognitoUser {
     if (getUserContextData() != null) {
       paramsReq['UserContextData'] = getUserContextData();
     }
-    await _analyticsMetadataParamsDecorator.call(paramsReq);
 
-    final data = await client.request('RespondToAuthChallenge', paramsReq);
+    final data = await client.request('RespondToAuthChallenge',
+        await _analyticsMetadataParamsDecorator.call(paramsReq));
 
     return _authenticateUserInternal(data, authenticationHelper);
   }
@@ -857,10 +856,9 @@ class CognitoUser {
     if (getUserContextData() != null) {
       paramsReq['UserContextData'] = getUserContextData();
     }
-    await _analyticsMetadataParamsDecorator.call(paramsReq);
 
-    final dataAuthenticate =
-        await client.request('RespondToAuthChallenge', paramsReq);
+    final dataAuthenticate = await client.request('RespondToAuthChallenge',
+        await _analyticsMetadataParamsDecorator.call(paramsReq));
 
     final String challengeName = dataAuthenticate['ChallengeName'];
 
@@ -1000,9 +998,9 @@ class CognitoUser {
     if (getUserContextData() != null) {
       paramsReq['UserContextData'] = getUserContextData();
     }
-    await _analyticsMetadataParamsDecorator.call(paramsReq);
 
-    return await client.request('ForgotPassword', paramsReq);
+    return await client.request('ForgotPassword',
+        await _analyticsMetadataParamsDecorator.call(paramsReq));
   }
 
   /// This is used to confirm a new password using a confirmation code
@@ -1020,9 +1018,9 @@ class CognitoUser {
     if (getUserContextData() != null) {
       paramsReq['UserContextData'] = getUserContextData();
     }
-    await _analyticsMetadataParamsDecorator.call(paramsReq);
 
-    await client.request('ConfirmForgotPassword', paramsReq);
+    await client.request('ConfirmForgotPassword',
+        await _analyticsMetadataParamsDecorator.call(paramsReq));
     return true;
   }
 

--- a/lib/src/cognito_user_pool.dart
+++ b/lib/src/cognito_user_pool.dart
@@ -44,8 +44,8 @@ class CognitoUserPool {
     this.storage,
     this.advancedSecurityDataCollectionFlag = true,
     ParamsDecorator analyticsMetadataParamsDecorator,
-  }) : _analyticsMetadataParamsDecorator = analyticsMetadataParamsDecorator ??
-      NoOpsParamsDecorator() {
+  }) : _analyticsMetadataParamsDecorator =
+            analyticsMetadataParamsDecorator ?? NoOpsParamsDecorator() {
     _userPoolId = userPoolId;
     _clientId = clientId;
     _clientSecret = clientSecret;
@@ -122,9 +122,9 @@ class CognitoUserPool {
       params['SecretHash'] = CognitoUser.calculateClientSecretHash(
           username, _clientId, _clientSecret);
     }
-    await _analyticsMetadataParamsDecorator.call(params);
 
-    final data = await client.request('SignUp', params);
+    final data = await client.request(
+        'SignUp', await _analyticsMetadataParamsDecorator.call(params));
     if (data == null) {
       return null;
     }

--- a/lib/src/params_decorators.dart
+++ b/lib/src/params_decorators.dart
@@ -1,9 +1,11 @@
 abstract class ParamsDecorator {
-  Future<void> call(Map<String, Object> params);
+  Future<Map<String, Object>> call(Map<String, Object> params);
 }
 
 class NoOpsParamsDecorator extends ParamsDecorator {
 
   @override
-  Future<void> call(Map<String, Object> params) async {}
+  Future<Map<String, Object>> call(Map<String, Object> params) async {
+    return params;
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: amazon_cognito_identity_dart_2
-version: 0.1.24+2
+version: 0.1.25
 homepage: https://github.com/furaiev/amazon-cognito-identity-dart-2
 description: Unofficial Amazon Cognito Identity Provider Dart SDK, to add user
   sign-up / sign-in to your mobile and web apps with AWS Cloud Services. Based


### PR DESCRIPTION
Within forgotPassword, confirmPassword and other operations, analyticsMetadataParamsDecorator receives a Map<String, String> as input (it implies its type as it is declared using "var"). When trying to add a new entry whose value is Map<String, String>, it fails with:

"type '_InternalLinkedHashMap<String, String>' is not a subtype of type 'String' of 'value'"