### PR TITLE
check for InvalidPasswordException in signup screen

### DIFF
--- a/example/lib/screens/signup_screen.dart
+++ b/example/lib/screens/signup_screen.dart
@@ -27,6 +27,7 @@ class _SignUpScreenState extends State<SignUpScreen> {
     } on CognitoClientException catch (e) {
       if (e.code == 'UsernameExistsException' ||
           e.code == 'InvalidParameterException' ||
+          e.code == 'InvalidPasswordException' ||
           e.code == 'ResourceNotFoundException') {
         message = e.message;
       } else {


### PR DESCRIPTION
Without this change, an invalid password (no capital letter, no symbol...) will popup "unknown client error"

With this change, you get a more explanatory message from the exception.

![9B2CA8BA-4CAC-4C17-9C08-45A3119C0841](https://user-images.githubusercontent.com/1530082/107467597-386eb300-6b1b-11eb-88a9-a25547e1feef.png)
