### PR TITLE
Fix broken lastAuthUser lookup in CognitoUser

### DIFF
--- a/lib/src/cognito_user.dart
+++ b/lib/src/cognito_user.dart
@@ -70,7 +70,8 @@ class CognitoUser {
         storage ?? (CognitoStorageHelper(CognitoMemoryStorage())).getStorage();
   }
 
-  String get keyPrefix => 'CognitoIdentityServiceProvider.${pool.getClientId()}.$username';
+  String get poolKeyPrefix => 'CognitoIdentityServiceProvider.${pool.getClientId()}';
+  String get keyPrefix => '$poolKeyPrefix.$username';
 
   Future<CognitoUserSession> _authenticateUserInternal(
       dataAuthenticate, AuthenticationHelper authenticationHelper) async {
@@ -246,7 +247,7 @@ class CognitoUser {
     final authParameters = {
       'REFRESH_TOKEN': refreshToken.getToken(),
     };
-    final lastUserKey = '$keyPrefix.LastAuthUser';
+    final lastUserKey = '$poolKeyPrefix.LastAuthUser';
 
     if (await storage.getItem(lastUserKey) != null) {
       username = await storage.getItem(lastUserKey);
@@ -1028,7 +1029,7 @@ class CognitoUser {
     final accessTokenKey = '$keyPrefix.accessToken';
     final refreshTokenKey = '$keyPrefix.refreshToken';
     final clockDriftKey = '$keyPrefix.clockDrift';
-    final lastUserKey = '$keyPrefix.LastAuthUser';
+    final lastUserKey = '$poolKeyPrefix.LastAuthUser';
 
     await Future.wait([
       storage.setItem(
@@ -1048,7 +1049,7 @@ class CognitoUser {
     final accessTokenKey = '$keyPrefix.accessToken';
     final refreshTokenKey = '$keyPrefix.refreshToken';
     final clockDriftKey = '$keyPrefix.clockDrift';
-    final lastUserKey = '$keyPrefix.LastAuthUser';
+    final lastUserKey = '$poolKeyPrefix.LastAuthUser';
 
     await Future.wait([
       storage.removeItem(idTokenKey),


### PR DESCRIPTION
## Why?

A refactor as part of #130 shifted a bit too much of code. It led to the change of key of the `LastAuthUser` attribute of the CognitoUser class from 
`CognitoIdentityServiceProvider.${pool.getClientId()}.LastAuthUser` to `CognitoIdentityServiceProvider.${pool.getClientId()}.$username.LastAuthUser`.

On the [User Pool class](https://github.com/furaiev/amazon-cognito-identity-dart-2/blob/4a0477dd236297100320154202b2fe8e255f2c19/lib/src/cognito_user_pool.dart#L81), the lastAuthUser is still looked up under the previous key...

## Changes
- Add a far from elegant `poolKeyPrefix` used only for the `LastAuthUser` in CognitoUser class
- Rewrite the keyPrefix as the `poolKeyPrefix.$username`


