### PR TITLE
fix(cognito): exports client.dart

### DIFF
--- a/lib/cognito.dart
+++ b/lib/cognito.dart
@@ -1,5 +1,6 @@
 export 'src/attribute_arg.dart';
 export 'src/authentication_details.dart';
+export 'src/client.dart';
 export 'src/cognito_client_exceptions.dart';
 export 'src/cognito_credentials.dart';
 export 'src/cognito_id_token.dart';


### PR DESCRIPTION
This change exports `client.dart` to facilitate using injection for automated testing.