### PR TITLE
Fix unexpected nullref during "initiateAuth"

### DIFF
--- a/lib/src/cognito_user.dart
+++ b/lib/src/cognito_user.dart
@@ -432,7 +432,7 @@ class CognitoUser {
   Future<CognitoUserSession?> initiateAuth(
       AuthenticationDetails authDetails) async {
     final authParameters =
-        authDetails.getAuthParameters()!.fold({}, (dynamic value, element) {
+        (authDetails.getAuthParameters() ?? []).fold({}, (dynamic value, element) {
       value[element.name] = element.value;
       return value;
     });


### PR DESCRIPTION
Since ```authParameters``` is optional parameter in```AuthenticationDetails``` we should avoid null reference exceptions if no value was passed.