### PR TITLE
Added optional clientMetadata to signup

### DIFF
--- a/example/lib/generated_plugin_registrant.dart
+++ b/example/lib/generated_plugin_registrant.dart
@@ -4,6 +4,7 @@
 
 // ignore_for_file: directives_ordering
 // ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: depend_on_referenced_packages
 
 import 'package:shared_preferences_web/shared_preferences_web.dart';
 

--- a/lib/src/cognito_user_pool.dart
+++ b/lib/src/cognito_user_pool.dart
@@ -104,19 +104,19 @@ class CognitoUserPool {
   }
 
   /// Registers the user in the specified user pool and creates a
-  /// user name, password, and user attributes.
-  Future<CognitoUserPoolData> signUp(
-    String username,
-    String password, {
-    List<AttributeArg>? userAttributes,
-    List<AttributeArg>? validationData,
-  }) async {
+  /// user name, password, optional user attributes, optional validation data
+  /// and optional client metadata.
+  Future<CognitoUserPoolData> signUp(String username, String password,
+      {List<AttributeArg>? userAttributes,
+      List<AttributeArg>? validationData,
+      Map<String, String>? clientMetadata}) async {
     final params = {
       'ClientId': _clientId,
       'Username': username,
       'Password': password,
       'UserAttributes': userAttributes,
       'ValidationData': validationData,
+      'ClientMetadata': clientMetadata
     };
 
     if (_clientSecret != null) {


### PR DESCRIPTION
The Signup process offered by the Amplify flutter package includes optional clientMetadata which is not offered here.  ClientMetadata has therefore been included as an optional argument to the class CognitoUserPool's signUp method in the form of Map<string,string> as required by the AWS Cognito docs.