### PR TITLE
Moving SECRET_HASH assignment out from unrelated condition block

### DIFF
--- a/lib/src/cognito_user.dart
+++ b/lib/src/cognito_user.dart
@@ -255,9 +255,10 @@ class CognitoUser {
       final deviceKeyKey = '$keyPrefix.deviceKey';
       _deviceKey = await storage.getItem(deviceKeyKey);
       authParameters['DEVICE_KEY'] = _deviceKey;
-      if (_clientSecretHash != null) {
-        authParameters['SECRET_HASH'] = _clientSecretHash;
-      }
+    }
+
+    if (_clientSecretHash != null) {
+      authParameters['SECRET_HASH'] = _clientSecretHash;
     }
 
     final paramsReq = {


### PR DESCRIPTION
## Summary
### Issue
`SECRET_HASH` header is not added in `refreshSession`.
### Cause
The step is enclosed by one if block, and it is unnecessary.
### Fix
Move the `SECRET_HASH` header insertion out of the block, like how it is done in other methods.

## Details:
If the Cognito App Client has set up a client secret, a `SECRET_HASH` header will be required to refresh the token.

One possible scenario will be:
1. User login to the app, Cognito returns Access Token, ID Token, Refresh Token.
2. App stored all tokens and username on the device (e.g. `shared_preferences`).
3. User closes the app and opens the app again after the access token or ID token is expired.
4. App attempts to generate new tokens with stored username and refresh token.
5. New tokens are generated and replace expired tokens.

So in step 4, my app failed to refresh the session because the secret hash is not added to the headers.
Current logic has one condition check before adding `SECRET_HASH`, which is unnecessary.