### PR TITLE
Regen SECRET_HASH using the srp username

### DIFF
--- a/lib/src/cognito_user.dart
+++ b/lib/src/cognito_user.dart
@@ -38,6 +38,7 @@ class CognitoUser {
   String? _session;
   CognitoUserSession? _signInUserSession;
   String? username;
+  String? _clientSecret;
   String? _clientSecretHash;
   CognitoUserPool pool;
   Client? client;
@@ -58,8 +59,9 @@ class CognitoUser {
   }) : _analyticsMetadataParamsDecorator =
             analyticsMetadataParamsDecorator ?? NoOpsParamsDecorator() {
     if (clientSecret != null) {
+      _clientSecret = clientSecret;
       _clientSecretHash = calculateClientSecretHash(
-          username!, pool.getClientId()!, clientSecret);
+          username!, pool.getClientId()!, _clientSecret!);
     }
     if (signInUserSession != null) {
       _signInUserSession = signInUserSession;
@@ -631,6 +633,10 @@ class CognitoUser {
     }
 
     if (_clientSecretHash != null) {
+      // Update client hash with the response from the auth challenge
+      _clientSecretHash = calculateClientSecretHash(
+          srpUsername, pool.getClientId()!, _clientSecret!);
+
       challengeResponses['SECRET_HASH'] = _clientSecretHash;
     }
 


### PR DESCRIPTION
As seen in the AWS Cognito Android SDK here https://github.com/aws-amplify/aws-sdk-android/blob/main/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/CognitoUser.java#L3602 the secretHash is regenerated again before sending the password challenge with the internal username.

Otherwise if you have a pool configured with a client secret you get the error ~ "secret hash does not match client id"

Thanks for a lovely lib! It opens the door for a web version of my app ❤️ 