### PR TITLE
Use clientSecret instead of client secret hash in refresh session

### DIFF
--- a/lib/src/cognito_user.dart
+++ b/lib/src/cognito_user.dart
@@ -262,8 +262,8 @@ class CognitoUser {
       authParameters['DEVICE_KEY'] = _deviceKey;
     }
 
-    if (_clientSecretHash != null) {
-      authParameters['SECRET_HASH'] = _clientSecretHash;
+    if (_clientSecret != null) {
+      authParameters['SECRET_HASH'] = _clientSecret;
     }
 
     final paramsReq = {


### PR DESCRIPTION
As seen in the AWS Cognito Android SDK here https://github.com/aws-amplify/aws-sdk-android/blob/main/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/CognitoUser.java#L3564 for the refresh session request it uses `clientSecret` and not `clientSecretHash` for the header `SECRET_HASH`.

Otherwise if you have a pool configured with a client secret you get the error ~ "secret hash does not match client id" when an user is trying to refresh a token, similar to https://github.com/furaiev/amazon-cognito-identity-dart-2/pull/211.