### PR TITLE
fix: CognitoUser.getSession throws TypeError when storage returns null for clockDrift

### DIFF
--- a/lib/src/cognito_user.dart
+++ b/lib/src/cognito_user.dart
@@ -193,7 +193,7 @@ class CognitoUser {
     final canRefreshToken = refreshToken.getToken() != null;
 
     final clockDriftValue = await storage.getItem(clockDriftKey);
-    final clockDrift = int.tryParse(clockDriftValue);
+    final clockDrift = int.tryParse(clockDriftValue ?? '');
 
     final idTokenValue = await storage.getItem(idTokenKey);
     if (idTokenValue == null) {


### PR DESCRIPTION
fixes: https://github.com/furaiev/amazon-cognito-identity-dart-2/issues/221