### PR TITLE
Better handling of unverified phone numbers using sms mfa

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ try {
 }
 ```
 
-__Use case 9.__ Enabling MFA for a user on a pool that has an optional MFA setting for authenticated users.
+__Use case 9.__ Enabling SMS-MFA for a user on a pool that has an optional MFA setting for authenticated users. The phone number needs to be verified
 
 ```dart
 bool mfaEnabled = false;

--- a/lib/src/cognito_user.dart
+++ b/lib/src/cognito_user.dart
@@ -989,7 +989,7 @@ class CognitoUser {
       throw Exception('User is not authenticated');
     }
     
-    bool? phoneNumberVerified = false;
+    bool phoneNumberVerified = false;
     final getUserParamsReq = {
       'AccessToken': _signInUserSession!.getAccessToken().getJwtToken(),
     };

--- a/lib/src/cognito_user_exceptions.dart
+++ b/lib/src/cognito_user_exceptions.dart
@@ -100,3 +100,14 @@ class CognitoUserConfirmationNecessaryException extends CognitoUserException {
   CognitoUserConfirmationNecessaryException(
       {this.signInUserSession, this.message = 'User Confirmation Necessary'});
 }
+
+class CognitoUserPhoneNumberVerificationNecessaryException
+    extends CognitoUserException {
+  @override
+  String? message;
+  CognitoUserSession? signInUserSession;
+
+  CognitoUserPhoneNumberVerificationNecessaryException(
+      {this.signInUserSession,
+      this.message = 'Verification of Attribute \'phone_number\' Necessary'});
+}

--- a/test/cognito_user_exceptions_test.dart
+++ b/test/cognito_user_exceptions_test.dart
@@ -137,4 +137,33 @@ void main() {
           equals('CognitoUserException: User Confirmation Necessary'));
     }
   });
+  test(
+      'throw CognitoUserPhoneNumberVerificationNecessaryException generates message',
+      () {
+    t() => throw CognitoUserPhoneNumberVerificationNecessaryException();
+    try {
+      t();
+    } on CognitoUserPhoneNumberVerificationNecessaryException catch (e) {
+      expect(
+          e.toString(),
+          equals(
+              'CognitoUserException: Verification of Attribute \'phone_number\' Necessary'));
+    }
+    try {
+      t();
+    } on CognitoUserException catch (e) {
+      expect(
+          e.toString(),
+          equals(
+              'CognitoUserException: Verification of Attribute \'phone_number\' Necessary'));
+    }
+    try {
+      t();
+    } catch (e) {
+      expect(
+          e.toString(),
+          equals(
+              'CognitoUserException: Verification of Attribute \'phone_number\' Necessary'));
+    }
+  });
 }


### PR DESCRIPTION
PR for https://github.com/furaiev/amazon-cognito-identity-dart-2/issues/223

Tested these changes with our app and it worked fine.

Currently there is only one way to get into a problematic state by having a verified phone number, then enabling MFA and later changing phone_number attribute and not verifying it but in my opinion this should be solved by the developer unsing this library. I added the information to the documentation though to be careful at this step.