### PR TITLE
#192 add specific exception that has nothing to do with user registra…

### DIFF
--- a/lib/src/cognito_user.dart
+++ b/lib/src/cognito_user.dart
@@ -956,7 +956,7 @@ class CognitoUser {
         ['DeviceKey'];
     await cacheDeviceKeyAndPassword();
     if (dataConfirm['UserConfirmationNecessary'] == true) {
-      throw CognitoUserConfirmationNecessaryException(
+      throw CognitoUserDeviceConfirmationNecessaryException(
           signInUserSession: _signInUserSession);
     }
 

--- a/lib/src/cognito_user_exceptions.dart
+++ b/lib/src/cognito_user_exceptions.dart
@@ -101,6 +101,17 @@ class CognitoUserConfirmationNecessaryException extends CognitoUserException {
       {this.signInUserSession, this.message = 'User Confirmation Necessary'});
 }
 
+class CognitoUserDeviceConfirmationNecessaryException
+    extends CognitoUserException {
+  @override
+  String? message;
+  CognitoUserSession? signInUserSession;
+
+  CognitoUserDeviceConfirmationNecessaryException(
+      {this.signInUserSession,
+      this.message = 'User Device Confirmation Necessary'});
+}
+
 class CognitoUserPhoneNumberVerificationNecessaryException
     extends CognitoUserException {
   @override


### PR DESCRIPTION
As mentioned as a reply on https://github.com/furaiev/amazon-cognito-identity-dart-2/issues/192
Hereby my PR to add a specific exception that can be handled whenever an users device needs confirmation