### PR TITLE
Correctly throw SocketException

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -46,7 +46,7 @@ class Client {
         body: body,
       );
     } catch (e) {
-      if (e.toString().contains('SocketException:')) {
+      if (e.cause is SocketException) {
         throw CognitoClientException(
           'SocketException',
           code: 'NetworkError',

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -46,7 +46,7 @@ class Client {
         body: body,
       );
     } catch (e) {
-      if (e.cause is SocketException) {
+      if (e.toString().contains('Failed host lookup:')) {
         throw CognitoClientException(
           'SocketException',
           code: 'NetworkError',


### PR DESCRIPTION
If you disable the network, it should throw a `SocketException`, yet it throws `Unknown Error`. This is because `e.toString()` does **not** contain `SocketException:`. The value for `e.toString()` is:

```
Failed host lookup: 'cognito-idp.eu-west-1.amazonaws.com'
```

This should solve this issue: https://github.com/furaiev/amazon-cognito-identity-dart-2/issues/207