### PR TITLE
Send secret hash in SMS MFA

### DIFF
--- a/lib/src/cognito_user.dart
+++ b/lib/src/cognito_user.dart
@@ -904,6 +904,9 @@ class CognitoUser {
     if (mfaType == 'SOFTWARE_TOKEN_MFA') {
       challengeResponses['SOFTWARE_TOKEN_MFA_CODE'] = confirmationCode;
     }
+    if (_clientSecretHash != null) {
+      challengeResponses['SECRET_HASH'] = _clientSecretHash;
+    }
 
     await getCachedDeviceKeyAndPassword();
     if (_deviceKey != null) {


### PR DESCRIPTION
Add the Secret Hash to SMS MFA requests.
I was unable to get SMS MFA working with our AWS setup until I added this, definitely let me know if this is incorrect or if I should be accomplishing this in a different way.

Thanks!