### PR TITLE
Add Optional Refresh Token Revocation on Sign-Out

### DIFF
--- a/lib/src/cognito_user.dart
+++ b/lib/src/cognito_user.dart
@@ -529,7 +529,18 @@ class CognitoUser {
   }
 
   /// This is used for the user to signOut of the application and clear the cached tokens.
-  Future<void> signOut() async {
+  /// If `revokeRefreshToken` is set to true, it will revoke the refresh token.
+  Future<void> signOut({bool revokeRefreshToken = false}) async {
+    if (revokeRefreshToken && _signInUserSession != null) {
+      final paramsReq = {
+        'ClientId': pool.getClientId(),
+        'Token': _signInUserSession!.getRefreshToken()!.getToken(),
+      };
+      if (_clientSecret != null) {
+        paramsReq['ClientSecret'] = _clientSecret;
+      }
+      await client!.request('RevokeToken', paramsReq);
+    }
     _signInUserSession = null;
     await clearCachedTokens();
   }


### PR DESCRIPTION
When users sign out, developers can now choose whether to revoke the refresh token. This helps improve security by preventing unauthorized access to user accounts.

Details:

- **New Option**: We added a revokeRefreshToken parameter to the `CognitoUser#signOut` function. It's optional and defaults to `false`.
- **What It Does**: When set to `true`, it revokes the refresh token, enhancing security by invalidating it after sign-out.
- **Why It Matters**: This gives developers more control over security and helps protect user accounts from unauthorized access.

[AWS API reference](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_RevokeToken.html#CognitoUserPools-RevokeToken-request-ClientSecret)

We're open to feedback and suggestions to make it even better.
