### PR TITLE
Added ClientMetaData to a parameter of respondToAuthChallenge

### DIFF
--- a/lib/src/cognito_user.dart
+++ b/lib/src/cognito_user.dart
@@ -727,6 +727,7 @@ class CognitoUser {
       'ClientId': pool.getClientId(),
       'ChallengeResponses': challengeResponses,
       'Session': data['Session'],
+      'ClientMetadata': authDetails.getValidationData(),
     };
 
     if (getUserContextData() != null) {


### PR DESCRIPTION
I added ClientMetaData to a parameter of respondToAuthChallenge in _authenticateUserDefaultAuth to give ClientMetadata to challenge lambda triggers.

Please consider merging.