### PR TITLE
confirmPassword should return response rather than always true

### DIFF
--- a/lib/src/cognito_user.dart
+++ b/lib/src/cognito_user.dart
@@ -1114,7 +1114,7 @@ class CognitoUser {
   }
 
   /// This is used to confirm a new password using a confirmation code
-  Future confirmPassword(
+  Future<bool> confirmPassword(
       String confirmationCode, String newPassword) async {
     final paramsReq = {
       'ClientId': pool.getClientId(),
@@ -1129,8 +1129,13 @@ class CognitoUser {
       paramsReq['UserContextData'] = getUserContextData();
     }
 
-    return await client!.request('ConfirmForgotPassword',
-        await _analyticsMetadataParamsDecorator.call(paramsReq));
+    try {
+      await client!.request('ConfirmForgotPassword',
+          await _analyticsMetadataParamsDecorator.call(paramsReq));
+      return true;
+    } catch (e) {
+      rethrow;
+    }
   }
 
   /// This is used to save the session tokens to local storage

--- a/lib/src/cognito_user.dart
+++ b/lib/src/cognito_user.dart
@@ -1114,7 +1114,7 @@ class CognitoUser {
   }
 
   /// This is used to confirm a new password using a confirmation code
-  Future<bool> confirmPassword(
+  Future confirmPassword(
       String confirmationCode, String newPassword) async {
     final paramsReq = {
       'ClientId': pool.getClientId(),

--- a/lib/src/cognito_user.dart
+++ b/lib/src/cognito_user.dart
@@ -1129,9 +1129,8 @@ class CognitoUser {
       paramsReq['UserContextData'] = getUserContextData();
     }
 
-    await client!.request('ConfirmForgotPassword',
+    return await client!.request('ConfirmForgotPassword',
         await _analyticsMetadataParamsDecorator.call(paramsReq));
-    return true;
   }
 
   /// This is used to save the session tokens to local storage


### PR DESCRIPTION
In `forgotPassword`, the result of the `ForgotPassword` request is returned from the function.
In `confirmPassword`, it runs the `ConfirmForgotPassword` request but then returns `true` and ignores the result.
`confirmPassword` should also return the result of the request.