### PR TITLE
confirmRegistration should return response rather than always true

### DIFF
--- a/lib/src/cognito_user.dart
+++ b/lib/src/cognito_user.dart
@@ -806,9 +806,13 @@ class CognitoUser {
       params['SecretHash'] = _clientSecretHash;
     }
 
-    await client!.request(
-        'ConfirmSignUp', await _analyticsMetadataParamsDecorator.call(params));
-    return true;
+    try {
+      await client!.request(
+          'ConfirmSignUp', await _analyticsMetadataParamsDecorator.call(params));
+      return true;
+    } catch (e) {
+      rethrow;
+    }
   }
 
   /// This is used by a user to resend a confirmation code


### PR DESCRIPTION
Good day @furaiev, I was wondering if we could do the same as #261 but for confirmRegistration?
That is the function I need right now, but I imagine for others it would be good to also change `verifyAttribute`, `changePassword`, `enableMfa`, `disableMfa`, `updateAttributes`, `deleteAttributes`, and `deleteUser` in the same way since they all return true always.
Possibly `setUserMfaPreference` should also rethrow inside the catch, instead of returning false as it does now.