### PR TITLE
Add support for new password challenge

### DIFF
--- a/lib/src/cognito_user.dart
+++ b/lib/src/cognito_user.dart
@@ -156,6 +156,22 @@ class CognitoUser {
           challengeParameters: challengeParameters);
     }
 
+    if (challengeName == 'NEW_PASSWORD_REQUIRED') {
+      _session = dataAuthenticate['Session'];
+      dynamic userAttributes = null;
+      List<dynamic>? requiredAttributes = [];
+      if (challengeParameters['userAttributes'] != null) {
+        userAttributes = json.decode(challengeParameters['userAttributes']);
+        requiredAttributes = json.decode(
+          challengeParameters['requiredAttributes'],
+        );
+      }
+      throw CognitoUserNewPasswordRequiredException(
+        userAttributes: userAttributes,
+        requiredAttributes: requiredAttributes,
+      );
+    }
+
     if (challengeName == 'DEVICE_SRP_AUTH') {
       await getDeviceResponse();
       return _signInUserSession;


### PR DESCRIPTION
👋 @furaiev ! Thanks for having this package in the first place :)

If `authenticationFlowType` is `USER_PASSWORD_AUTH` and it gets the challenge `NEW_PASSWORD_REQUIRED`, it should return `CognitoUserNewPasswordRequiredException`.

This PR aims to fix that 😄 