### PR TITLE
On web, asynchronous setItems causes concurrency issues.

### DIFF
--- a/lib/src/cognito_user.dart
+++ b/lib/src/cognito_user.dart
@@ -1168,16 +1168,14 @@ class CognitoUser {
     final refreshTokenKey = '$keyPrefix.refreshToken';
     final clockDriftKey = '$keyPrefix.clockDrift';
 
-    await Future.wait([
-      storage.setItem(
-          idTokenKey, _signInUserSession?.getIdToken().getJwtToken()),
-      storage.setItem(
-          accessTokenKey, _signInUserSession?.getAccessToken().getJwtToken()),
-      storage.setItem(
-          refreshTokenKey, _signInUserSession?.getRefreshToken()?.getToken()),
-      storage.setItem(clockDriftKey, '${_signInUserSession?.getClockDrift()}'),
-      storage.setItem(pool.lastUserKey, username),
-    ]);
+    await storage.setItem(
+      idTokenKey, _signInUserSession?.getIdToken().getJwtToken());
+    await storage.setItem(
+      accessTokenKey, _signInUserSession?.getAccessToken().getJwtToken());
+    await storage.setItem(
+      refreshTokenKey, _signInUserSession?.getRefreshToken()?.getToken());
+    await storage.setItem(clockDriftKey, '${_signInUserSession?.getClockDrift()}');
+    await storage.setItem(pool.lastUserKey, username);
   }
 
   /// This is used to clear the session tokens from local storage


### PR DESCRIPTION
Good day. When signing in on a Flutter web app, it calls cacheTokens and then when following the setItem calls with breakpoints, it throws "OperationError" on every call. This is fixed when awaiting each setItem call.

This error seems to be related: https://github.com/juliansteenbakker/flutter_secure_storage/issues/381